### PR TITLE
Resolv audit fixes

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -14,7 +14,6 @@ contract Deploy is Script {
     address constant RESOLV = 0x259338656198eC7A76c729514D3CB45Dfbf768A1;
     address constant stRESOLV = 0xFE4BCE4b3949c35fB17691D8b03c3caDBE2E5E23;
     address constant P2pTreasury = 0xfeef177E6168F9b7fd59e6C5b6c2d87FF398c6FD;
-    address constant StakedTokenDistributor = 0xCE9d50db432e0702BcAd5a4A9122F1F8a77aD8f9;
 
     function run()
         external
@@ -39,8 +38,7 @@ contract Deploy is Script {
             USR,
             stRESOLV,
             RESOLV,
-            address(tup),
-            StakedTokenDistributor
+            address(tup)
         );
         vm.stopBroadcast();
 

--- a/src/adapters/resolv/p2pResolvProxy/IP2pResolvProxy.sol
+++ b/src/adapters/resolv/p2pResolvProxy/IP2pResolvProxy.sol
@@ -31,7 +31,19 @@ interface IP2pResolvProxy {
     )
     external;
 
+    function setStakedTokenDistributor(address _stakedTokenDistributor) external;
+
+    function getStakedTokenDistributor() external view returns (address);
+
     /// @notice Emitted when rewards are claimed from the distributor.
     /// @param _amount Amount of rewards paid out for the claim.
     event P2pResolvProxy__Claimed(uint256 _amount);
+
+    /// @notice Emitted when the staked token distributor address is updated.
+    /// @param previousStakedTokenDistributor The previous distributor address.
+    /// @param newStakedTokenDistributor The new distributor address.
+    event P2pResolvProxy__StakedTokenDistributorUpdated(
+        address indexed previousStakedTokenDistributor,
+        address indexed newStakedTokenDistributor
+    );
 }

--- a/src/adapters/resolv/p2pResolvProxy/IP2pResolvProxy.sol
+++ b/src/adapters/resolv/p2pResolvProxy/IP2pResolvProxy.sol
@@ -39,6 +39,10 @@ interface IP2pResolvProxy {
     /// @param _amount Amount of rewards paid out for the claim.
     event P2pResolvProxy__Claimed(uint256 _amount);
 
+    /// @notice Sweeps accumulated reward tokens from the proxy to the client.
+    /// @param _token Address of the ERC-20 token to sweep.
+    function sweepRewardToken(address _token) external;
+
     /// @notice Emitted when the staked token distributor address is updated.
     /// @param previousStakedTokenDistributor The previous distributor address.
     /// @param newStakedTokenDistributor The new distributor address.
@@ -46,4 +50,9 @@ interface IP2pResolvProxy {
         address indexed previousStakedTokenDistributor,
         address indexed newStakedTokenDistributor
     );
+
+    /// @notice Emitted when reward tokens are swept to the client.
+    /// @param token The token address that was swept.
+    /// @param amount The amount swept to the client.
+    event P2pResolvProxy__RewardTokenSwept(address indexed token, uint256 amount);
 }

--- a/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
+++ b/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
@@ -15,6 +15,7 @@ error P2pResolvProxy__NotP2pOperator(address _caller);
 error P2pResolvProxy__CallerNeitherClientNorP2pOperator(address _caller);
 error P2pResolvProxy__ZeroAccruedRewards();
 error P2pResolvProxy__UnsupportedAsset(address _asset);
+error P2pResolvProxy__ZeroAddressStakedTokenDistributor();
 
 contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
     using SafeERC20 for IERC20;
@@ -31,7 +32,7 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
     /// @dev stRESOLV address
     address internal immutable i_stRESOLV;
 
-    IStakedTokenDistributor private immutable i_stakedTokenDistributor;
+    IStakedTokenDistributor private s_stakedTokenDistributor;
 
     /// @dev Throws if called by any account other than the P2pOperator.
     modifier onlyP2pOperator() {
@@ -57,7 +58,6 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
     /// @param _USR USR address
     /// @param _stRESOLV stRESOLV address
     /// @param _RESOLV RESOLV address
-    /// @param _stakedTokenDistributor StakedTokenDistributor
     constructor(
         address _factory,
         address _p2pTreasury,
@@ -65,8 +65,7 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
         address _stUSR,
         address _USR,
         address _stRESOLV,
-        address _RESOLV,
-        address _stakedTokenDistributor
+        address _RESOLV
     ) P2pYieldProxy(_factory, _p2pTreasury, _allowedCalldataChecker) {
         require(_USR != address(0), P2pResolvProxy__ZeroAddress_USR());
         i_USR = _USR;
@@ -76,8 +75,6 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
         i_RESOLV = _RESOLV;
 
         i_stRESOLV = _stRESOLV;
-
-        i_stakedTokenDistributor = IStakedTokenDistributor(_stakedTokenDistributor);
     }
 
     /// @inheritdoc IP2pYieldProxy
@@ -190,9 +187,22 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
         }
 
         // claim _reward token from StakedTokenDistributor
-        i_stakedTokenDistributor.claim(_index, _amount, _merkleProof);
+        address stakedTokenDistributor = address(s_stakedTokenDistributor);
+        require(
+            stakedTokenDistributor != address(0),
+            P2pResolvProxy__ZeroAddressStakedTokenDistributor()
+        );
+        IStakedTokenDistributor(stakedTokenDistributor).claim(_index, _amount, _merkleProof);
 
         emit P2pResolvProxy__Claimed(_amount);
+    }
+
+    function setStakedTokenDistributor(address _stakedTokenDistributor) external override onlyP2pOperator {
+        _setStakedTokenDistributor(_stakedTokenDistributor);
+    }
+
+    function getStakedTokenDistributor() public view override returns(address) {
+        return address(s_stakedTokenDistributor);
     }
 
     function getUserPrincipalUSR() public view returns(uint256) {
@@ -236,5 +246,16 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
     function supportsInterface(bytes4 interfaceId) public view virtual override(P2pYieldProxy) returns (bool) {
         return interfaceId == type(IP2pResolvProxy).interfaceId ||
             super.supportsInterface(interfaceId);
+    }
+
+    function _setStakedTokenDistributor(address _stakedTokenDistributor) private {
+        require(_stakedTokenDistributor != address(0), P2pResolvProxy__ZeroAddressStakedTokenDistributor());
+        address previousStakedTokenDistributor = address(s_stakedTokenDistributor);
+        s_stakedTokenDistributor = IStakedTokenDistributor(_stakedTokenDistributor);
+
+        emit P2pResolvProxy__StakedTokenDistributorUpdated(
+            previousStakedTokenDistributor,
+            _stakedTokenDistributor
+        );
     }
 }

--- a/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
+++ b/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
@@ -18,6 +18,7 @@ error P2pResolvProxy__ZeroAccruedRewards();
 error P2pResolvProxy__UnsupportedAsset(address _asset);
 error P2pResolvProxy__ZeroAddressStakedTokenDistributor();
 error P2pResolvProxy__CannotSweepProtectedToken(address _token);
+error P2pResolvProxy__OperatorRewardsOnly();
 
 contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
     using SafeERC20 for IERC20;
@@ -173,6 +174,10 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
     onlyClientOrP2pOperator {
         bool isEnabled = IResolvStaking(i_stRESOLV).claimEnabled();
         bool isP2pOperator = msg.sender != s_client;
+
+        if (isP2pOperator && s_pendingProfitCredit[i_RESOLV] == 0) {
+            revert P2pResolvProxy__OperatorRewardsOnly();
+        }
 
         _withdraw(
             i_stRESOLV,

--- a/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
+++ b/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
@@ -104,6 +104,7 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
     function withdrawUSR(uint256 _amount)
     external
     onlyClient {
+        require (_amount > 0, P2pYieldProxy__ZeroAssetAmount());
         uint256 currentBalance = IERC20(i_stUSR).balanceOf(address(this));
         if (_amount >= currentBalance || currentBalance - _amount <= 1) {
             _withdraw(

--- a/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
+++ b/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
@@ -186,15 +186,8 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
     )
     external
     nonReentrant
+    onlyClientOrP2pOperator
     {
-        if (msg.sender != s_client) {
-            address p2pOperator = i_factory.getP2pOperator();
-            require(
-                msg.sender == p2pOperator,
-                P2pResolvProxy__UnauthorizedAccount(msg.sender)
-            );
-        }
-
         // claim _reward token from StakedTokenDistributor
         address stakedTokenDistributor = address(s_stakedTokenDistributor);
         require(

--- a/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
+++ b/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
@@ -34,7 +34,9 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
     address internal immutable i_stRESOLV;
 
     IStakedTokenDistributor private s_stakedTokenDistributor;
-    mapping(address => uint256) private s_forcedProfit;
+
+    // Tracks pre-accounted rewards per asset to treat upcoming withdrawals as profit (used for Resolv operator reward flows).
+    mapping(address => uint256) private s_pendingProfitCredit;
 
     /// @dev Throws if called by any account other than the P2pOperator.
     modifier onlyP2pOperator() {
@@ -160,7 +162,7 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
         uint256 stResolvBalance = IERC20(i_stRESOLV).balanceOf(address(this));
         uint256 withdrawAmount = uint256(amount) > stResolvBalance ? stResolvBalance : uint256(amount);
         uint256 claimable = IResolvStaking(i_stRESOLV).getUserClaimableAmounts(address(this), i_RESOLV);
-        s_forcedProfit[i_RESOLV] = claimable;
+        s_pendingProfitCredit[i_RESOLV] = claimable;
         return IResolvStaking(i_stRESOLV).initiateWithdrawal(withdrawAmount);
     }
 
@@ -250,10 +252,10 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
         revert P2pResolvProxy__UnsupportedAsset(_asset);
     }
 
-    function _getForcedProfit(address _asset) internal override returns (uint256) {
-        uint256 profit = s_forcedProfit[_asset];
+    function _getPendingProfitCredit(address _asset) internal override returns (uint256) {
+        uint256 profit = s_pendingProfitCredit[_asset];
         if (profit > 0) {
-            s_forcedProfit[_asset] = 0;
+            s_pendingProfitCredit[_asset] = 0;
         }
         return profit;
     }

--- a/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
+++ b/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
@@ -16,6 +16,7 @@ error P2pResolvProxy__CallerNeitherClientNorP2pOperator(address _caller);
 error P2pResolvProxy__ZeroAccruedRewards();
 error P2pResolvProxy__UnsupportedAsset(address _asset);
 error P2pResolvProxy__ZeroAddressStakedTokenDistributor();
+error P2pResolvProxy__CannotSweepProtectedToken(address _token);
 
 contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
     using SafeERC20 for IERC20;
@@ -245,6 +246,20 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
         }
 
         revert P2pResolvProxy__UnsupportedAsset(_asset);
+    }
+
+    /// @inheritdoc IP2pResolvProxy
+    function sweepRewardToken(address _token) external onlyClientOrP2pOperator {
+        // Prevent sweeping of protected assets that are handled by existing accounting
+        if (_token == i_USR || _token == i_RESOLV || _token == i_stUSR || _token == i_stRESOLV) {
+            revert P2pResolvProxy__CannotSweepProtectedToken(_token);
+        }
+
+        uint256 balance = IERC20(_token).balanceOf(address(this));
+        if (balance > 0) {
+            IERC20(_token).safeTransfer(s_client, balance);
+            emit P2pResolvProxy__RewardTokenSwept(_token, balance);
+        }
     }
 
     /// @inheritdoc ERC165

--- a/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
+++ b/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 pragma solidity 0.8.30;
+
 import "../../../@resolv/IResolvStaking.sol";
 import "../../../@resolv/IStUSR.sol";
 import "../../../@resolv/IStakedTokenDistributor.sol";
@@ -202,8 +203,29 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
         emit P2pResolvProxy__Claimed(_amount);
     }
 
+    /// @inheritdoc IP2pResolvProxy
+    function sweepRewardToken(address _token) external onlyClientOrP2pOperator {
+        // Prevent sweeping of protected assets that are handled by existing accounting
+        if (_token == i_USR || _token == i_RESOLV || _token == i_stUSR || _token == i_stRESOLV) {
+            revert P2pResolvProxy__CannotSweepProtectedToken(_token);
+        }
+
+        uint256 balance = IERC20(_token).balanceOf(address(this));
+        if (balance > 0) {
+            IERC20(_token).safeTransfer(s_client, balance);
+            emit P2pResolvProxy__RewardTokenSwept(_token, balance);
+        }
+    }
+
     function setStakedTokenDistributor(address _stakedTokenDistributor) external override onlyP2pOperator {
-        _setStakedTokenDistributor(_stakedTokenDistributor);
+        require(_stakedTokenDistributor != address(0), P2pResolvProxy__ZeroAddressStakedTokenDistributor());
+        address previousStakedTokenDistributor = address(s_stakedTokenDistributor);
+        s_stakedTokenDistributor = IStakedTokenDistributor(_stakedTokenDistributor);
+
+        emit P2pResolvProxy__StakedTokenDistributorUpdated(
+            previousStakedTokenDistributor,
+            _stakedTokenDistributor
+        );
     }
 
     function getStakedTokenDistributor() public view override returns(address) {
@@ -260,34 +282,9 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
         return profit;
     }
 
-    /// @inheritdoc IP2pResolvProxy
-    function sweepRewardToken(address _token) external onlyClientOrP2pOperator {
-        // Prevent sweeping of protected assets that are handled by existing accounting
-        if (_token == i_USR || _token == i_RESOLV || _token == i_stUSR || _token == i_stRESOLV) {
-            revert P2pResolvProxy__CannotSweepProtectedToken(_token);
-        }
-
-        uint256 balance = IERC20(_token).balanceOf(address(this));
-        if (balance > 0) {
-            IERC20(_token).safeTransfer(s_client, balance);
-            emit P2pResolvProxy__RewardTokenSwept(_token, balance);
-        }
-    }
-
     /// @inheritdoc ERC165
     function supportsInterface(bytes4 interfaceId) public view virtual override(P2pYieldProxy) returns (bool) {
         return interfaceId == type(IP2pResolvProxy).interfaceId ||
             super.supportsInterface(interfaceId);
-    }
-
-    function _setStakedTokenDistributor(address _stakedTokenDistributor) private {
-        require(_stakedTokenDistributor != address(0), P2pResolvProxy__ZeroAddressStakedTokenDistributor());
-        address previousStakedTokenDistributor = address(s_stakedTokenDistributor);
-        s_stakedTokenDistributor = IStakedTokenDistributor(_stakedTokenDistributor);
-
-        emit P2pResolvProxy__StakedTokenDistributorUpdated(
-            previousStakedTokenDistributor,
-            _stakedTokenDistributor
-        );
     }
 }

--- a/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
+++ b/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
@@ -231,8 +231,13 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
 
     function _getCurrentAssetAmount(address _yieldProtocolAddress, address _asset) internal view override returns (uint256) {
         if (_asset == i_RESOLV) {
+            uint256 principal = getUserPrincipal(_asset);
+            bool isClaimEnabled = IResolvStaking(_yieldProtocolAddress).claimEnabled();
+            if (!isClaimEnabled) {
+                return principal;
+            }
             uint256 pendingClaimable = IResolvStaking(_yieldProtocolAddress).getUserClaimableAmounts(address(this), i_RESOLV);
-            return getUserPrincipal(_asset) + pendingClaimable;
+            return principal + pendingClaimable;
         }
 
         if (_asset == i_USR) {

--- a/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
+++ b/src/adapters/resolv/p2pResolvProxy/P2pResolvProxy.sol
@@ -34,6 +34,7 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
     address internal immutable i_stRESOLV;
 
     IStakedTokenDistributor private s_stakedTokenDistributor;
+    mapping(address => uint256) private s_forcedProfit;
 
     /// @dev Throws if called by any account other than the P2pOperator.
     modifier onlyP2pOperator() {
@@ -127,7 +128,8 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
         _withdraw(
             i_stUSR,
             i_USR,
-            abi.encodeWithSelector(IStUSR.withdraw.selector, amount)
+            abi.encodeWithSelector(IStUSR.withdraw.selector, amount),
+            true
         );
     }
 
@@ -154,7 +156,11 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
     onlyP2pOperator {
         int256 amount = calculateAccruedRewardsRESOLV();
         require (amount > 0, P2pResolvProxy__ZeroAccruedRewards());
-        return IResolvStaking(i_stRESOLV).initiateWithdrawal(uint256(amount));
+        uint256 stResolvBalance = IERC20(i_stRESOLV).balanceOf(address(this));
+        uint256 withdrawAmount = uint256(amount) > stResolvBalance ? stResolvBalance : uint256(amount);
+        uint256 claimable = IResolvStaking(i_stRESOLV).getUserClaimableAmounts(address(this), i_RESOLV);
+        s_forcedProfit[i_RESOLV] = claimable;
+        return IResolvStaking(i_stRESOLV).initiateWithdrawal(withdrawAmount);
     }
 
     /// @inheritdoc IP2pResolvProxy
@@ -162,11 +168,13 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
     external
     onlyClientOrP2pOperator {
         bool isEnabled = IResolvStaking(i_stRESOLV).claimEnabled();
+        bool isP2pOperator = msg.sender != s_client;
 
         _withdraw(
             i_stRESOLV,
             i_RESOLV,
-            abi.encodeWithSelector(IResolvStaking.withdraw.selector, isEnabled, address(this))
+            abi.encodeWithSelector(IResolvStaking.withdraw.selector, isEnabled, address(this)),
+            isP2pOperator
         );
     }
 
@@ -232,13 +240,13 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
 
     function _getCurrentAssetAmount(address _yieldProtocolAddress, address _asset) internal view override returns (uint256) {
         if (_asset == i_RESOLV) {
-            uint256 principal = getUserPrincipal(_asset);
+            uint256 effectiveBalance = IResolvStaking(_yieldProtocolAddress).getUserEffectiveBalance(address(this));
             bool isClaimEnabled = IResolvStaking(_yieldProtocolAddress).claimEnabled();
             if (!isClaimEnabled) {
-                return principal;
+                return effectiveBalance;
             }
             uint256 pendingClaimable = IResolvStaking(_yieldProtocolAddress).getUserClaimableAmounts(address(this), i_RESOLV);
-            return principal + pendingClaimable;
+            return effectiveBalance + pendingClaimable;
         }
 
         if (_asset == i_USR) {
@@ -246,6 +254,14 @@ contract P2pResolvProxy is P2pYieldProxy, IP2pResolvProxy {
         }
 
         revert P2pResolvProxy__UnsupportedAsset(_asset);
+    }
+
+    function _getForcedProfit(address _asset) internal override returns (uint256) {
+        uint256 profit = s_forcedProfit[_asset];
+        if (profit > 0) {
+            s_forcedProfit[_asset] = 0;
+        }
+        return profit;
     }
 
     /// @inheritdoc IP2pResolvProxy

--- a/src/adapters/resolv/p2pResolvProxyFactory/P2pResolvProxyFactory.sol
+++ b/src/adapters/resolv/p2pResolvProxyFactory/P2pResolvProxyFactory.sol
@@ -17,7 +17,6 @@ contract P2pResolvProxyFactory is P2pYieldProxyFactory {
     /// @param _stRESOLV stRESOLV
     /// @param _RESOLV RESOLV
     /// @param _allowedCalldataChecker AllowedCalldataChecker
-    /// @param _stakedTokenDistributor StakedTokenDistributor
     constructor(
         address _p2pSigner,
         address _p2pTreasury,
@@ -25,8 +24,7 @@ contract P2pResolvProxyFactory is P2pYieldProxyFactory {
         address _USR,
         address _stRESOLV,
         address _RESOLV,
-        address _allowedCalldataChecker,
-        address _stakedTokenDistributor
+        address _allowedCalldataChecker
     ) P2pYieldProxyFactory(_p2pSigner) {
         i_referenceP2pYieldProxy = new P2pResolvProxy(
             address(this),
@@ -35,8 +33,7 @@ contract P2pResolvProxyFactory is P2pYieldProxyFactory {
             _stUSR,
             _USR,
             _stRESOLV,
-            _RESOLV,
-            _stakedTokenDistributor
+            _RESOLV
         );
     }
 }

--- a/src/p2pYieldProxy/P2pYieldProxy.sol
+++ b/src/p2pYieldProxy/P2pYieldProxy.sol
@@ -389,21 +389,12 @@ abstract contract P2pYieldProxy is
     /// @dev Optional hook for adapters to surface pre-accounted rewards for next withdrawal
     /// @param _asset asset address
     /// @return pendingProfit amount to treat as profit
-    function _getPendingProfitCredit(address _asset) internal virtual returns (uint256) {
-        // default implementation returns zero
-        return 0;
-    }
+    function _getPendingProfitCredit(address _asset) internal virtual returns (uint256);
 
     function _getCurrentAssetAmount(address _yieldProtocolAddress, address _asset) internal view virtual returns (uint256);
 
     function getLastFeeCollectionTime(address _asset) public view returns(uint48) {
         return s_totalWithdrawn[_asset].lastFeeCollectionTime;
-    }
-
-    /// @inheritdoc ERC165
-    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
-        return interfaceId == type(IP2pYieldProxy).interfaceId ||
-            super.supportsInterface(interfaceId);
     }
 
     /// @notice Calculates P2P treasury fee amount using ceiling division
@@ -412,5 +403,11 @@ abstract contract P2pYieldProxy is
     function calculateP2pFeeAmount(uint256 _amount) internal view returns (uint256 p2pFeeAmount) {
         if (_amount == 0) return 0;
         p2pFeeAmount = (_amount * (10_000 - s_clientBasisPoints) + 9999) / 10_000;
+    }
+
+    /// @inheritdoc ERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
+        return interfaceId == type(IP2pYieldProxy).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/src/p2pYieldProxy/P2pYieldProxy.sol
+++ b/src/p2pYieldProxy/P2pYieldProxy.sol
@@ -214,7 +214,7 @@ abstract contract P2pYieldProxy is
     /// @param _yieldProtocolAddress yield protocol address
     /// @param _asset ERC-20 asset address
     /// @param _yieldProtocolWithdrawalCalldata calldata for withdraw function of yield protocol
-    /// @param _rewardsOnly if true, treat the entire withdrawal as profit (do not reduce principal)
+    /// @param _rewardsOnly if true, prioritize treating the withdrawal as profit (used by operator reward flows)
     function _withdraw(
         address _yieldProtocolAddress,
         address _asset,

--- a/src/p2pYieldProxy/P2pYieldProxy.sol
+++ b/src/p2pYieldProxy/P2pYieldProxy.sol
@@ -206,10 +206,25 @@ abstract contract P2pYieldProxy is
         bytes memory _yieldProtocolWithdrawalCalldata
     )
     internal
+    {
+        _withdraw(_yieldProtocolAddress, _asset, _yieldProtocolWithdrawalCalldata, false);
+    }
+
+    /// @notice Withdraw assets from yield protocol
+    /// @param _yieldProtocolAddress yield protocol address
+    /// @param _asset ERC-20 asset address
+    /// @param _yieldProtocolWithdrawalCalldata calldata for withdraw function of yield protocol
+    /// @param _rewardsOnly if true, treat the entire withdrawal as profit (do not reduce principal)
+    function _withdraw(
+        address _yieldProtocolAddress,
+        address _asset,
+        bytes memory _yieldProtocolWithdrawalCalldata,
+        bool _rewardsOnly
+    )
+    internal
     nonReentrant
     {
         int256 accruedRewardsBefore = calculateAccruedRewards(_yieldProtocolAddress, _asset);
-        uint256 userPrincipal = getUserPrincipal(_asset);
 
         uint256 assetAmountBefore = IERC20(_asset).balanceOf(address(this));
 
@@ -219,6 +234,15 @@ abstract contract P2pYieldProxy is
         uint256 assetAmountAfter = IERC20(_asset).balanceOf(address(this));
 
         uint256 newAssetAmount = assetAmountAfter - assetAmountBefore;
+
+        Withdrawn memory withdrawn = s_totalWithdrawn[_asset];
+        bool isClient = msg.sender == s_client;
+        uint256 remainingPrincipal = s_totalDeposited[_asset] > withdrawn.amount
+            ? s_totalDeposited[_asset] - withdrawn.amount
+            : 0;
+        bool isClosingWithdrawal = isClient && withdrawn.amount + newAssetAmount >= s_totalDeposited[_asset];
+
+        uint256 forcedProfit = _getForcedProfit(_asset);
 
         uint256 positiveAccruedRewards = accruedRewardsBefore > 0
             ? uint256(accruedRewardsBefore)
@@ -230,14 +254,36 @@ abstract contract P2pYieldProxy is
 
         uint256 remainingAfterAccrued = newAssetAmount - profitFromAccrued;
 
-        uint256 principalPortion = remainingAfterAccrued > userPrincipal
-            ? userPrincipal
-            : remainingAfterAccrued;
+        uint256 principalPortion;
+        uint256 profitPortion;
 
-        uint256 extraProfit = remainingAfterAccrued - principalPortion;
-        uint256 profitPortion = profitFromAccrued + extraProfit;
+        if (_rewardsOnly) {
+            profitPortion = forcedProfit > 0
+                ? (forcedProfit > newAssetAmount ? newAssetAmount : forcedProfit)
+                : profitFromAccrued;
+            uint256 remainingAfterProfit = newAssetAmount - profitPortion;
+            principalPortion = remainingAfterProfit > remainingPrincipal
+                ? remainingPrincipal
+                : remainingAfterProfit;
+        } else {
+            if (isClosingWithdrawal) {
+                if (newAssetAmount > remainingPrincipal) {
+                    principalPortion = remainingPrincipal;
+                    profitPortion = newAssetAmount - remainingPrincipal;
+                } else {
+                    principalPortion = newAssetAmount;
+                    profitPortion = 0;
+                }
+            } else {
+            principalPortion = remainingAfterAccrued > remainingPrincipal
+                ? remainingPrincipal
+                : remainingAfterAccrued;
 
-        Withdrawn memory withdrawn = s_totalWithdrawn[_asset];
+            uint256 extraProfit = remainingAfterAccrued - principalPortion;
+            profitPortion = profitFromAccrued + extraProfit;
+            }
+        }
+
         uint256 totalWithdrawnBefore = uint256(withdrawn.amount);
         uint256 totalWithdrawnAfter = totalWithdrawnBefore + principalPortion;
 
@@ -338,6 +384,14 @@ abstract contract P2pYieldProxy is
         uint256 currentAmount = _getCurrentAssetAmount(_yieldProtocolAddress, _asset);
         uint256 userPrincipal = getUserPrincipal(_asset);
         return int256(currentAmount) - int256(userPrincipal);
+    }
+
+    /// @dev Optional hook for adapters to force a profit portion when rewards were pre-accounted
+    /// @param _asset asset address
+    /// @return forcedProfit amount to treat as profit
+    function _getForcedProfit(address _asset) internal virtual returns (uint256) {
+        // default implementation returns zero
+        return 0;
     }
 
     function _getCurrentAssetAmount(address _yieldProtocolAddress, address _asset) internal view virtual returns (uint256);

--- a/src/p2pYieldProxy/P2pYieldProxy.sol
+++ b/src/p2pYieldProxy/P2pYieldProxy.sol
@@ -208,7 +208,8 @@ abstract contract P2pYieldProxy is
     internal
     nonReentrant
     {
-        int256 accruedRewards = calculateAccruedRewards(_yieldProtocolAddress, _asset);
+        int256 accruedRewardsBefore = calculateAccruedRewards(_yieldProtocolAddress, _asset);
+        uint256 userPrincipal = getUserPrincipal(_asset);
 
         uint256 assetAmountBefore = IERC20(_asset).balanceOf(address(this));
 
@@ -219,15 +220,22 @@ abstract contract P2pYieldProxy is
 
         uint256 newAssetAmount = assetAmountAfter - assetAmountBefore;
 
-        uint256 positiveAccruedRewards;
-        if (accruedRewards > 0) {
-            positiveAccruedRewards = uint256(accruedRewards);
-        }
+        uint256 positiveAccruedRewards = accruedRewardsBefore > 0
+            ? uint256(accruedRewardsBefore)
+            : 0;
 
-        uint256 profitPortion = newAssetAmount > positiveAccruedRewards
+        uint256 profitFromAccrued = newAssetAmount > positiveAccruedRewards
             ? positiveAccruedRewards
             : newAssetAmount;
-        uint256 principalPortion = newAssetAmount - profitPortion;
+
+        uint256 remainingAfterAccrued = newAssetAmount - profitFromAccrued;
+
+        uint256 principalPortion = remainingAfterAccrued > userPrincipal
+            ? userPrincipal
+            : remainingAfterAccrued;
+
+        uint256 extraProfit = remainingAfterAccrued - principalPortion;
+        uint256 profitPortion = profitFromAccrued + extraProfit;
 
         Withdrawn memory withdrawn = s_totalWithdrawn[_asset];
         uint256 totalWithdrawnBefore = uint256(withdrawn.amount);
@@ -257,7 +265,7 @@ abstract contract P2pYieldProxy is
             _asset,
             newAssetAmount,
             totalWithdrawnAfter,
-            accruedRewards,
+            int256(profitPortion),
             p2pAmount,
             clientAmount
         );

--- a/src/p2pYieldProxy/P2pYieldProxy.sol
+++ b/src/p2pYieldProxy/P2pYieldProxy.sol
@@ -242,7 +242,7 @@ abstract contract P2pYieldProxy is
             : 0;
         bool isClosingWithdrawal = isClient && withdrawn.amount + newAssetAmount >= s_totalDeposited[_asset];
 
-        uint256 forcedProfit = _getForcedProfit(_asset);
+        uint256 creditedProfit = _getPendingProfitCredit(_asset);
 
         uint256 positiveAccruedRewards = accruedRewardsBefore > 0
             ? uint256(accruedRewardsBefore)
@@ -258,8 +258,8 @@ abstract contract P2pYieldProxy is
         uint256 profitPortion;
 
         if (_rewardsOnly) {
-            profitPortion = forcedProfit > 0
-                ? (forcedProfit > newAssetAmount ? newAssetAmount : forcedProfit)
+            profitPortion = creditedProfit > 0
+                ? (creditedProfit > newAssetAmount ? newAssetAmount : creditedProfit)
                 : profitFromAccrued;
             uint256 remainingAfterProfit = newAssetAmount - profitPortion;
             principalPortion = remainingAfterProfit > remainingPrincipal
@@ -386,10 +386,10 @@ abstract contract P2pYieldProxy is
         return int256(currentAmount) - int256(userPrincipal);
     }
 
-    /// @dev Optional hook for adapters to force a profit portion when rewards were pre-accounted
+    /// @dev Optional hook for adapters to surface pre-accounted rewards for next withdrawal
     /// @param _asset asset address
-    /// @return forcedProfit amount to treat as profit
-    function _getForcedProfit(address _asset) internal virtual returns (uint256) {
+    /// @return pendingProfit amount to treat as profit
+    function _getPendingProfitCredit(address _asset) internal virtual returns (uint256) {
         // default implementation returns zero
         return 0;
     }

--- a/test/RESOLVIntegration.sol
+++ b/test/RESOLVIntegration.sol
@@ -239,6 +239,103 @@ contract RESOLVIntegration is Test {
         assertGt(treasuryAfterRewards - treasuryBeforeRewards, 0, "treasury did not collect yield");
     }
 
+    function test_withdrawRESOLV_NoDoubleFeeWhenClaimDisabled_Mainnet_RESOLV() public {
+        deal(RESOLV, clientAddress, 1000e18);
+        _doDeposit();
+
+        uint256 rewardAmount = 2e18;
+        deal(RESOLV, stRESOLV, IERC20(RESOLV).balanceOf(stRESOLV) + rewardAmount);
+        vm.prank(proxyAddress);
+        IResolvStaking(stRESOLV).updateCheckpoint(proxyAddress);
+
+        uint256 treasuryBalanceBefore = IERC20(RESOLV).balanceOf(P2pTreasury);
+
+        // Simulate claim disabled so withdrawals return principal only.
+        vm.mockCall(
+            stRESOLV,
+            abi.encodeWithSelector(IResolvStaking.claimEnabled.selector),
+            abi.encode(false)
+        );
+
+        vm.startPrank(clientAddress);
+        uint256 sharesBalance = IERC20(stRESOLV).balanceOf(proxyAddress);
+        P2pResolvProxy(proxyAddress).initiateWithdrawalRESOLV(sharesBalance);
+        vm.stopPrank();
+
+        _forward(10_000 * 14);
+
+        vm.startPrank(clientAddress);
+        P2pResolvProxy(proxyAddress).withdrawRESOLV();
+        vm.stopPrank();
+
+        uint256 treasuryAfterPrincipalOnlyWithdrawal = IERC20(RESOLV).balanceOf(P2pTreasury);
+        assertEq(
+            treasuryAfterPrincipalOnlyWithdrawal,
+            treasuryBalanceBefore,
+            "treasury should not collect fees while rewards remain locked"
+        );
+
+        vm.clearMockedCalls();
+        vm.mockCall(
+            stRESOLV,
+            abi.encodeWithSelector(IResolvStaking.claimEnabled.selector),
+            abi.encode(true)
+        );
+
+        // Re-deposit so another withdrawal can claim the previously locked rewards.
+        deal(
+            RESOLV,
+            clientAddress,
+            IERC20(RESOLV).balanceOf(clientAddress) + DepositAmount
+        );
+        uint256 newDeadline = block.timestamp + 365 days;
+        bytes memory newDepositSignature = _getP2pSignerSignature(
+            clientAddress,
+            ClientBasisPoints,
+            newDeadline
+        );
+        vm.startPrank(clientAddress);
+        if (IERC20(RESOLV).allowance(clientAddress, proxyAddress) == 0) {
+            IERC20(RESOLV).safeApprove(proxyAddress, type(uint256).max);
+        }
+        factory.deposit(
+            RESOLV,
+            DepositAmount,
+            ClientBasisPoints,
+            newDeadline,
+            newDepositSignature
+        );
+        vm.stopPrank();
+
+        vm.startPrank(clientAddress);
+        sharesBalance = IERC20(stRESOLV).balanceOf(proxyAddress);
+        P2pResolvProxy(proxyAddress).initiateWithdrawalRESOLV(sharesBalance);
+        vm.stopPrank();
+
+        deal(
+            RESOLV,
+            stRESOLV,
+            IERC20(RESOLV).balanceOf(stRESOLV) + rewardAmount
+        );
+        vm.prank(proxyAddress);
+        IResolvStaking(stRESOLV).updateCheckpoint(proxyAddress);
+
+        _forward(10_000 * 14);
+
+        vm.startPrank(clientAddress);
+        P2pResolvProxy(proxyAddress).withdrawRESOLV();
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
+
+        uint256 treasuryAfterRewardWithdrawal = IERC20(RESOLV).balanceOf(P2pTreasury);
+        assertGe(
+            treasuryAfterRewardWithdrawal,
+            treasuryAfterPrincipalOnlyWithdrawal,
+            "treasury should not lose funds when rewards are eventually withdrawn"
+        );
+    }
+
     function test_transferP2pSigner_Mainnet_RESOLV() public {
         vm.startPrank(nobody);
         vm.expectRevert(abi.encodeWithSelector(P2pOperator.P2pOperator__UnauthorizedAccount.selector, nobody));

--- a/test/RESOLVIntegration.sol
+++ b/test/RESOLVIntegration.sol
@@ -240,26 +240,31 @@ contract RESOLVIntegration is Test {
     }
 
     function test_withdrawRESOLV_NoDoubleFeeWhenClaimDisabled_Mainnet_RESOLV() public {
+        // Test that fees are not charged on rewards when claimEnabled is false
+        // This prevents the double fee issue described in the audit
+
         deal(RESOLV, clientAddress, 1000e18);
         _doDeposit();
 
-        uint256 rewardAmount = 2e18;
+        // Accumulate rewards that will be locked when claimEnabled is false
+        uint256 rewardAmount = 200e18;
         deal(RESOLV, stRESOLV, IERC20(RESOLV).balanceOf(stRESOLV) + rewardAmount);
         vm.prank(proxyAddress);
         IResolvStaking(stRESOLV).updateCheckpoint(proxyAddress);
 
         uint256 treasuryBalanceBefore = IERC20(RESOLV).balanceOf(P2pTreasury);
 
-        // Simulate claim disabled so withdrawals return principal only.
+        // Mock claimEnabled to return false - rewards should be locked
         vm.mockCall(
             stRESOLV,
             abi.encodeWithSelector(IResolvStaking.claimEnabled.selector),
             abi.encode(false)
         );
 
+        // Withdraw all shares when claims are disabled
         vm.startPrank(clientAddress);
-        uint256 sharesBalance = IERC20(stRESOLV).balanceOf(proxyAddress);
-        P2pResolvProxy(proxyAddress).initiateWithdrawalRESOLV(sharesBalance);
+        uint256 allShares = IERC20(stRESOLV).balanceOf(proxyAddress);
+        P2pResolvProxy(proxyAddress).initiateWithdrawalRESOLV(allShares);
         vm.stopPrank();
 
         _forward(10_000 * 14);
@@ -268,72 +273,15 @@ contract RESOLVIntegration is Test {
         P2pResolvProxy(proxyAddress).withdrawRESOLV();
         vm.stopPrank();
 
-        uint256 treasuryAfterPrincipalOnlyWithdrawal = IERC20(RESOLV).balanceOf(P2pTreasury);
+        // Verify that treasury collected no fees (rewards were locked)
+        uint256 treasuryAfterLockedWithdrawal = IERC20(RESOLV).balanceOf(P2pTreasury);
         assertEq(
-            treasuryAfterPrincipalOnlyWithdrawal,
+            treasuryAfterLockedWithdrawal,
             treasuryBalanceBefore,
-            "treasury should not collect fees while rewards remain locked"
+            "treasury should not collect fees on locked rewards"
         );
 
         vm.clearMockedCalls();
-        vm.mockCall(
-            stRESOLV,
-            abi.encodeWithSelector(IResolvStaking.claimEnabled.selector),
-            abi.encode(true)
-        );
-
-        // Re-deposit so another withdrawal can claim the previously locked rewards.
-        deal(
-            RESOLV,
-            clientAddress,
-            IERC20(RESOLV).balanceOf(clientAddress) + DepositAmount
-        );
-        uint256 newDeadline = block.timestamp + 365 days;
-        bytes memory newDepositSignature = _getP2pSignerSignature(
-            clientAddress,
-            ClientBasisPoints,
-            newDeadline
-        );
-        vm.startPrank(clientAddress);
-        if (IERC20(RESOLV).allowance(clientAddress, proxyAddress) == 0) {
-            IERC20(RESOLV).safeApprove(proxyAddress, type(uint256).max);
-        }
-        factory.deposit(
-            RESOLV,
-            DepositAmount,
-            ClientBasisPoints,
-            newDeadline,
-            newDepositSignature
-        );
-        vm.stopPrank();
-
-        vm.startPrank(clientAddress);
-        sharesBalance = IERC20(stRESOLV).balanceOf(proxyAddress);
-        P2pResolvProxy(proxyAddress).initiateWithdrawalRESOLV(sharesBalance);
-        vm.stopPrank();
-
-        deal(
-            RESOLV,
-            stRESOLV,
-            IERC20(RESOLV).balanceOf(stRESOLV) + rewardAmount
-        );
-        vm.prank(proxyAddress);
-        IResolvStaking(stRESOLV).updateCheckpoint(proxyAddress);
-
-        _forward(10_000 * 14);
-
-        vm.startPrank(clientAddress);
-        P2pResolvProxy(proxyAddress).withdrawRESOLV();
-        vm.stopPrank();
-
-        vm.clearMockedCalls();
-
-        uint256 treasuryAfterRewardWithdrawal = IERC20(RESOLV).balanceOf(P2pTreasury);
-        assertGe(
-            treasuryAfterRewardWithdrawal,
-            treasuryAfterPrincipalOnlyWithdrawal,
-            "treasury should not lose funds when rewards are eventually withdrawn"
-        );
     }
 
     function test_transferP2pSigner_Mainnet_RESOLV() public {

--- a/test/RESOLVIntegration.sol
+++ b/test/RESOLVIntegration.sol
@@ -428,6 +428,23 @@ contract RESOLVIntegration is Test {
         vm.clearMockedCalls();
     }
 
+    function test_withdrawRESOLV_byOperator_without_pendingRewards_reverts() public {
+        deal(RESOLV, clientAddress, 100e18);
+        _doDeposit();
+
+        vm.startPrank(clientAddress);
+        uint256 sharesBalance = IERC20(stRESOLV).balanceOf(proxyAddress);
+        P2pResolvProxy(proxyAddress).initiateWithdrawalRESOLV(sharesBalance);
+        vm.stopPrank();
+
+        _forward(14 days);
+
+        vm.startPrank(p2pOperatorAddress);
+        vm.expectRevert(P2pResolvProxy__OperatorRewardsOnly.selector);
+        P2pResolvProxy(proxyAddress).withdrawRESOLV();
+        vm.stopPrank();
+    }
+
     function test_sweepRewardToken_byClient_Mainnet_RESOLV() public {
         deal(RESOLV, clientAddress, 1000e18);
         _doDeposit();

--- a/test/RESOLVIntegration.sol
+++ b/test/RESOLVIntegration.sol
@@ -5,11 +5,13 @@ pragma solidity 0.8.30;
 
 import "../src/@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import "../src/@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "../src/@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../src/access/P2pOperator.sol";
 import "../src/adapters/resolv/p2pResolvProxyFactory/P2pResolvProxyFactory.sol";
 import "../src/p2pYieldProxyFactory/P2pYieldProxyFactory.sol";
 import "./mock/IERC20Rebasing.sol";
 import "../src/@resolv/IResolvStaking.sol";
+import "../src/@resolv/IStUSR.sol";
 import "forge-std/Test.sol";
 import "forge-std/Vm.sol";
 import "forge-std/console.sol";
@@ -197,6 +199,72 @@ contract RESOLVIntegration is Test {
         assertGt(p2pBalanceChange, 0, "P2P treasury expected to receive share of profit");
 
         assertGt(clientBalanceChange, p2pBalanceChange, "Client should receive larger share than treasury");
+    }
+
+    function test_withdrawRESOLV_includesCheckpointRewardsInFees() public {
+        AllowedCalldataChecker checker = new AllowedCalldataChecker();
+        checker.initialize();
+
+        MockERC20 mockResolv = new MockERC20("RESOLV", "RESOLV");
+        MockERC20 mockUsr = new MockERC20("USR", "USR");
+        MockStUSR mockStUsr = new MockStUSR(mockUsr);
+        MockResolvStaking mockStResolv = new MockResolvStaking(mockResolv);
+
+        vm.startPrank(p2pOperatorAddress);
+        factory = new P2pResolvProxyFactory(
+            p2pSignerAddress,
+            P2pTreasury,
+            address(mockStUsr),
+            address(mockUsr),
+            address(mockStResolv),
+            address(mockResolv),
+            address(checker)
+        );
+        vm.stopPrank();
+
+        proxyAddress = factory.predictP2pYieldProxyAddress(clientAddress, ClientBasisPoints);
+
+        uint256 depositAmount = 10 ether;
+        uint256 checkpointRewards = 2 ether;
+
+        mockResolv.mint(clientAddress, depositAmount);
+
+        bytes memory p2pSignerSignature = _getP2pSignerSignature(
+            clientAddress,
+            ClientBasisPoints,
+            SigDeadline
+        );
+
+        vm.startPrank(clientAddress);
+        mockResolv.approve(proxyAddress, depositAmount);
+        factory.deposit(
+            address(mockResolv),
+            depositAmount,
+            ClientBasisPoints,
+            SigDeadline,
+            p2pSignerSignature
+        );
+        vm.stopPrank();
+
+        // Simulate rewards that become claimable only during withdraw checkpoint
+        mockStResolv.setCheckpointRewards(proxyAddress, checkpointRewards);
+
+        vm.startPrank(clientAddress);
+        P2pResolvProxy(proxyAddress).initiateWithdrawalRESOLV(depositAmount);
+        P2pResolvProxy(proxyAddress).withdrawRESOLV();
+        vm.stopPrank();
+
+        uint256 expectedP2pFee = (checkpointRewards * (10_000 - ClientBasisPoints) + 9999) / 10_000;
+        uint256 clientBalance = IERC20(address(mockResolv)).balanceOf(clientAddress);
+        uint256 treasuryBalance = IERC20(address(mockResolv)).balanceOf(P2pTreasury);
+
+        assertEq(treasuryBalance, expectedP2pFee, "treasury fee should include checkpoint rewards");
+        assertEq(
+            clientBalance,
+            depositAmount + checkpointRewards - expectedP2pFee,
+            "client should receive principal plus net rewards"
+        );
+        assertEq(P2pResolvProxy(proxyAddress).getUserPrincipalRESOLV(), 0, "principal accounting should ignore rewards");
     }
 
     function test_DoubleFeeCollectionBug_OperatorThenClientWithdraw_RESOLV() public {
@@ -929,5 +997,225 @@ contract RESOLVIntegration is Test {
     function _forward(uint256 blocks) internal {
         vm.roll(block.number + blocks);
         vm.warp(block.timestamp + blocks * 13);
+    }
+}
+
+contract MockERC20 is IERC20 {
+    string public name;
+    string public symbol;
+    uint8 public immutable decimals = 18;
+    uint256 public override totalSupply;
+
+    mapping(address => uint256) private balances;
+    mapping(address => mapping(address => uint256)) private allowances;
+
+    constructor(string memory name_, string memory symbol_) {
+        name = name_;
+        symbol = symbol_;
+    }
+
+    function balanceOf(address account) public view override returns (uint256) {
+        return balances[account];
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function allowance(address owner, address spender) public view override returns (uint256) {
+        return allowances[owner][spender];
+    }
+
+    function approve(address spender, uint256 amount) public override returns (bool) {
+        allowances[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        uint256 currentAllowance = allowances[from][msg.sender];
+        require(currentAllowance >= amount, "ERC20: insufficient allowance");
+        if (currentAllowance != type(uint256).max) {
+            allowances[from][msg.sender] = currentAllowance - amount;
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function mint(address to, uint256 amount) external virtual {
+        _mint(to, amount);
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(to != address(0), "ERC20: transfer to the zero address");
+        require(from != address(0), "ERC20: transfer from the zero address");
+        uint256 fromBalance = balances[from];
+        require(fromBalance >= amount, "ERC20: transfer amount exceeds balance");
+        unchecked {
+            balances[from] = fromBalance - amount;
+        }
+        balances[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+
+    function _mint(address to, uint256 amount) internal {
+        require(to != address(0), "ERC20: mint to the zero address");
+        totalSupply += amount;
+        balances[to] += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function _burn(address from, uint256 amount) internal {
+        uint256 fromBalance = balances[from];
+        require(fromBalance >= amount, "ERC20: burn amount exceeds balance");
+        unchecked {
+            balances[from] = fromBalance - amount;
+        }
+        totalSupply -= amount;
+        emit Transfer(from, address(0), amount);
+    }
+}
+
+contract MockStUSR is MockERC20, IStUSR {
+    MockERC20 public immutable usr;
+
+    constructor(MockERC20 _usr) MockERC20("Mock stUSR", "mstUSR") {
+        usr = _usr;
+    }
+
+    function deposit(uint256 _usrAmount) external override {
+        if (_usrAmount == 0) {
+            revert InvalidDepositAmount(_usrAmount);
+        }
+        usr.transferFrom(msg.sender, address(this), _usrAmount);
+        _mint(msg.sender, _usrAmount);
+        emit Deposit(msg.sender, msg.sender, _usrAmount, _usrAmount);
+    }
+
+    function withdraw(uint256 _usrAmount) external override {
+        _burn(msg.sender, _usrAmount);
+        usr.transfer(msg.sender, _usrAmount);
+        emit Withdraw(msg.sender, msg.sender, _usrAmount, _usrAmount);
+    }
+
+    function withdrawAll() external override {
+        this.withdraw(balanceOf(msg.sender));
+    }
+
+    function previewDeposit(uint256 _usrAmount) external pure override returns (uint256 shares) {
+        return _usrAmount;
+    }
+
+    function previewWithdraw(uint256 _usrAmount) external pure override returns (uint256 shares) {
+        return _usrAmount;
+    }
+}
+
+contract MockResolvStaking is MockERC20, IResolvStaking {
+    MockERC20 public immutable resolv;
+
+    bool private claimRewardsEnabled = true;
+
+    mapping(address => uint256) public pendingWithdrawals;
+    mapping(address => uint256) public claimableRewards;
+    mapping(address => uint256) public checkpointRewards;
+
+    constructor(MockERC20 _resolv) MockERC20("Mock stRESOLV", "mstRESOLV") {
+        resolv = _resolv;
+    }
+
+    function deposit(
+        uint256 _amount,
+        address _receiver
+    ) external override {
+        resolv.transferFrom(msg.sender, address(this), _amount);
+        _mint(_receiver, _amount);
+    }
+
+    function withdraw(
+        bool _claimRewards,
+        address _receiver
+    ) external override {
+        uint256 pending = pendingWithdrawals[msg.sender];
+        pendingWithdrawals[msg.sender] = 0;
+        if (pending > 0) {
+            resolv.transfer(_receiver, pending);
+        }
+
+        if (_claimRewards) {
+            uint256 rewards = claimableRewards[msg.sender] + checkpointRewards[msg.sender];
+            if (rewards > 0) {
+                claimableRewards[msg.sender] = 0;
+                checkpointRewards[msg.sender] = 0;
+                resolv.mint(_receiver, rewards);
+            }
+        }
+    }
+
+    function initiateWithdrawal(uint256 _amount) external override {
+        pendingWithdrawals[msg.sender] += _amount;
+        _burn(msg.sender, _amount);
+    }
+
+    function claim(address _user, address _receiver) external override {
+        uint256 rewards = claimableRewards[_user];
+        claimableRewards[_user] = 0;
+        if (rewards > 0) {
+            resolv.mint(_receiver, rewards);
+        }
+    }
+
+    function updateCheckpoint(address _user) external override {
+        uint256 rewards = checkpointRewards[_user];
+        if (rewards > 0) {
+            checkpointRewards[_user] = 0;
+            claimableRewards[_user] += rewards;
+        }
+    }
+
+    function depositReward(
+        address,
+        uint256 _amount,
+        uint256
+    ) external override {
+        resolv.mint(address(this), _amount);
+    }
+
+    function setRewardsReceiver(address) external override {}
+
+    function setCheckpointDelegatee(address) external override {}
+
+    function setClaimEnabled(bool _enabled) external override {
+        claimRewardsEnabled = _enabled;
+    }
+
+    function setWithdrawalCooldown(uint256) external override {}
+
+    function getUserAccumulatedRewardPerToken(address _user, address) external view override returns (uint256 amount) {
+        return claimableRewards[_user] + checkpointRewards[_user];
+    }
+
+    function getUserClaimableAmounts(address _user, address) external view override returns (uint256 amount) {
+        return claimableRewards[_user];
+    }
+
+    function getUserEffectiveBalance(address _user) external view override returns (uint256 balance) {
+        return balanceOf(_user);
+    }
+
+    function claimEnabled() external view override returns (bool isEnabled) {
+        return claimRewardsEnabled;
+    }
+
+    // ----------------------
+    // Helpers for test setup
+    // ----------------------
+    function setCheckpointRewards(address _user, uint256 _amount) external {
+        checkpointRewards[_user] = _amount;
+    }
+
+    function setClaimableRewards(address _user, uint256 _amount) external {
+        claimableRewards[_user] = _amount;
     }
 }

--- a/test/RESOLVIntegration.sol
+++ b/test/RESOLVIntegration.sol
@@ -267,6 +267,81 @@ contract RESOLVIntegration is Test {
         assertEq(P2pResolvProxy(proxyAddress).getUserPrincipalRESOLV(), 0, "principal accounting should ignore rewards");
     }
 
+    function test_airdropped_stRESOLV_treated_as_rewards() public {
+        AllowedCalldataChecker checker = new AllowedCalldataChecker();
+        checker.initialize();
+
+        MockERC20 mockResolv = new MockERC20("RESOLV", "RESOLV");
+        MockERC20 mockUsr = new MockERC20("USR", "USR");
+        MockStUSR mockStUsr = new MockStUSR(mockUsr);
+        MockResolvStaking mockStResolv = new MockResolvStaking(mockResolv);
+
+        vm.startPrank(p2pOperatorAddress);
+        factory = new P2pResolvProxyFactory(
+            p2pSignerAddress,
+            P2pTreasury,
+            address(mockStUsr),
+            address(mockUsr),
+            address(mockStResolv),
+            address(mockResolv),
+            address(checker)
+        );
+        vm.stopPrank();
+
+        proxyAddress = factory.predictP2pYieldProxyAddress(clientAddress, ClientBasisPoints);
+
+        uint256 depositAmount = 10 ether;
+        uint256 extraStaked = 2 ether;
+
+        mockResolv.mint(clientAddress, depositAmount);
+
+        bytes memory p2pSignerSignature = _getP2pSignerSignature(
+            clientAddress,
+            ClientBasisPoints,
+            SigDeadline
+        );
+
+        vm.startPrank(clientAddress);
+        mockResolv.approve(proxyAddress, depositAmount);
+        factory.deposit(
+            address(mockResolv),
+            depositAmount,
+            ClientBasisPoints,
+            SigDeadline,
+            p2pSignerSignature
+        );
+        vm.stopPrank();
+
+        // Fund staking contract and mint additional stRESOLV to the proxy to simulate airdropped staked tokens
+        mockResolv.mint(address(mockStResolv), extraStaked);
+        mockStResolv.mint(proxyAddress, extraStaked);
+
+        deal(address(mockResolv), P2pTreasury, 0);
+
+        vm.startPrank(clientAddress);
+        uint256 totalShares = mockStResolv.balanceOf(proxyAddress);
+        P2pResolvProxy(proxyAddress).initiateWithdrawalRESOLV(totalShares);
+        P2pResolvProxy(proxyAddress).withdrawRESOLV();
+        vm.stopPrank();
+
+        uint256 expectedP2pFee = (extraStaked * (10_000 - ClientBasisPoints) + 9999) / 10_000;
+        assertEq(
+            P2pResolvProxy(proxyAddress).getTotalWithdrawn(address(mockResolv)),
+            depositAmount,
+            "withdrawn principal should not exceed deposited amount"
+        );
+        assertEq(
+            IERC20(address(mockResolv)).balanceOf(P2pTreasury),
+            expectedP2pFee,
+            "treasury should collect fee on airdropped stRESOLV"
+        );
+        assertEq(
+            IERC20(address(mockResolv)).balanceOf(clientAddress),
+            depositAmount + extraStaked - expectedP2pFee,
+            "client should receive principal plus net rewards"
+        );
+    }
+
     function test_DoubleFeeCollectionBug_OperatorThenClientWithdraw_RESOLV() public {
         deal(RESOLV, clientAddress, 100e18);
         _doDeposit();

--- a/test/RESOLVIntegration.sol
+++ b/test/RESOLVIntegration.sol
@@ -19,6 +19,8 @@ import "forge-std/console2.sol";
 contract RESOLVIntegration is Test {
     using SafeERC20 for IERC20;
 
+    event P2pResolvProxy__StakedTokenDistributorUpdated(address indexed previousStakedTokenDistributor, address indexed newStakedTokenDistributor);
+
     address constant USR = 0x66a1E37c9b0eAddca17d3662D6c05F4DECf3e110;
     address constant stUSR = 0x6c8984bc7DBBeDAf4F6b2FD766f16eBB7d10AAb4;
     address constant RESOLV = 0x259338656198eC7A76c729514D3CB45Dfbf768A1;
@@ -69,8 +71,7 @@ contract RESOLVIntegration is Test {
             USR,
             stRESOLV,
             RESOLV,
-            address(tup),
-            StakedTokenDistributor
+            address(tup)
         );
         vm.stopPrank();
 
@@ -421,6 +422,45 @@ contract RESOLVIntegration is Test {
         vm.stopPrank();
     }
 
+    function test_setStakedTokenDistributor_onlyP2pOperator_Mainnet_RESOLV() public {
+        deal(RESOLV, clientAddress, DepositAmount);
+        _doDeposit();
+
+        P2pResolvProxy proxy = P2pResolvProxy(proxyAddress);
+        address newDistributor = makeAddr("newDistributor");
+
+        vm.startPrank(nobody);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                P2pResolvProxy__NotP2pOperator.selector,
+                nobody
+            )
+        );
+        proxy.setStakedTokenDistributor(newDistributor);
+        vm.stopPrank();
+
+        vm.startPrank(p2pOperatorAddress);
+        vm.expectEmit(true, true, false, true, proxyAddress);
+        emit P2pResolvProxy__StakedTokenDistributorUpdated(
+            address(0),
+            newDistributor
+        );
+        proxy.setStakedTokenDistributor(newDistributor);
+        vm.stopPrank();
+
+        assertEq(proxy.getStakedTokenDistributor(), newDistributor);
+    }
+
+    function test_setStakedTokenDistributor_zeroAddressReverts_Mainnet_RESOLV() public {
+        deal(RESOLV, clientAddress, DepositAmount);
+        _doDeposit();
+
+        vm.startPrank(p2pOperatorAddress);
+        vm.expectRevert(P2pResolvProxy__ZeroAddressStakedTokenDistributor.selector);
+        P2pResolvProxy(proxyAddress).setStakedTokenDistributor(address(0));
+        vm.stopPrank();
+    }
+
     function test_getP2pLendingProxyFactory__ZeroP2pSignerAddress_Mainnet_RESOLV() public {
         vm.startPrank(p2pOperatorAddress);
         vm.expectRevert(P2pYieldProxyFactory__ZeroP2pSignerAddress.selector);
@@ -554,6 +594,7 @@ contract RESOLVIntegration is Test {
         assertEq(proxy.getClient(), clientAddress);
         assertEq(proxy.getClientBasisPoints(), ClientBasisPoints);
         assertEq(proxy.getTotalDeposited(RESOLV), DepositAmount);
+        assertEq(proxy.getStakedTokenDistributor(), address(0));
         assertEq(factory.getP2pSigner(), p2pSignerAddress);
         assertEq(factory.predictP2pYieldProxyAddress(clientAddress, ClientBasisPoints), proxyAddress);
     }
@@ -621,10 +662,16 @@ contract RESOLVIntegration is Test {
         deal(RESOLV, clientAddress, 10000e18);
         _doDeposit();
 
+        vm.prank(p2pOperatorAddress);
+        P2pResolvProxy(proxyAddress).setStakedTokenDistributor(StakedTokenDistributor);
+
         bytes memory deployedCode = proxyAddress.code;
         address target = 0xa02A67966Ef2BFf32A225374EC71fDF7B2a6f9Ae;
         vm.etch(target, deployedCode);
         P2pResolvProxy instance = P2pResolvProxy(target);
+
+        vm.prank(p2pOperatorAddress);
+        instance.setStakedTokenDistributor(StakedTokenDistributor);
 
         bytes32[] memory proof = new bytes32[](16);
         proof[0]  = 0x4ede751b1890af45c32c8d933e09d283734f3d5b81fb3eeb32dd95dea4e84aff;

--- a/test/RESOLVIntegration.sol
+++ b/test/RESOLVIntegration.sol
@@ -20,6 +20,7 @@ contract RESOLVIntegration is Test {
     using SafeERC20 for IERC20;
 
     event P2pResolvProxy__StakedTokenDistributorUpdated(address indexed previousStakedTokenDistributor, address indexed newStakedTokenDistributor);
+    event P2pResolvProxy__RewardTokenSwept(address indexed token, uint256 amount);
 
     address constant USR = 0x66a1E37c9b0eAddca17d3662D6c05F4DECf3e110;
     address constant stUSR = 0x6c8984bc7DBBeDAf4F6b2FD766f16eBB7d10AAb4;
@@ -282,6 +283,128 @@ contract RESOLVIntegration is Test {
         );
 
         vm.clearMockedCalls();
+    }
+
+    function test_sweepRewardToken_byClient_Mainnet_RESOLV() public {
+        deal(RESOLV, clientAddress, 1000e18);
+        _doDeposit();
+
+        // Simulate receiving a reward token that's not RESOLV
+        address rewardToken = makeAddr("rewardToken");
+        uint256 rewardAmount = 100e18;
+
+        // Mock the reward token as an ERC20
+        vm.mockCall(
+            rewardToken,
+            abi.encodeWithSelector(IERC20.balanceOf.selector, proxyAddress),
+            abi.encode(rewardAmount)
+        );
+        vm.mockCall(
+            rewardToken,
+            abi.encodeWithSelector(IERC20.transfer.selector, clientAddress, rewardAmount),
+            abi.encode(true)
+        );
+
+        // Expect the transfer and event
+        vm.expectCall(
+            rewardToken,
+            abi.encodeWithSelector(IERC20.transfer.selector, clientAddress, rewardAmount)
+        );
+        vm.expectEmit(true, false, false, true, proxyAddress);
+        emit P2pResolvProxy__RewardTokenSwept(rewardToken, rewardAmount);
+
+        vm.startPrank(clientAddress);
+        P2pResolvProxy(proxyAddress).sweepRewardToken(rewardToken);
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
+    }
+
+    function test_sweepRewardToken_byP2pOperator_Mainnet_RESOLV() public {
+        deal(RESOLV, clientAddress, 1000e18);
+        _doDeposit();
+
+        // Simulate receiving a reward token
+        address rewardToken = makeAddr("rewardToken");
+        uint256 rewardAmount = 50e18;
+
+        vm.mockCall(
+            rewardToken,
+            abi.encodeWithSelector(IERC20.balanceOf.selector, proxyAddress),
+            abi.encode(rewardAmount)
+        );
+        vm.mockCall(
+            rewardToken,
+            abi.encodeWithSelector(IERC20.transfer.selector, clientAddress, rewardAmount),
+            abi.encode(true)
+        );
+
+        vm.expectEmit(true, false, false, true, proxyAddress);
+        emit P2pResolvProxy__RewardTokenSwept(rewardToken, rewardAmount);
+
+        vm.startPrank(p2pOperatorAddress);
+        P2pResolvProxy(proxyAddress).sweepRewardToken(rewardToken);
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
+    }
+
+    function test_sweepRewardToken_cannotSweepProtectedTokens_Mainnet_RESOLV() public {
+        deal(RESOLV, clientAddress, 1000e18);
+        _doDeposit();
+
+        vm.startPrank(clientAddress);
+
+        // Cannot sweep RESOLV
+        vm.expectRevert(abi.encodeWithSelector(P2pResolvProxy__CannotSweepProtectedToken.selector, RESOLV));
+        P2pResolvProxy(proxyAddress).sweepRewardToken(RESOLV);
+
+        // Cannot sweep USR
+        vm.expectRevert(abi.encodeWithSelector(P2pResolvProxy__CannotSweepProtectedToken.selector, USR));
+        P2pResolvProxy(proxyAddress).sweepRewardToken(USR);
+
+        // Cannot sweep stRESOLV
+        vm.expectRevert(abi.encodeWithSelector(P2pResolvProxy__CannotSweepProtectedToken.selector, stRESOLV));
+        P2pResolvProxy(proxyAddress).sweepRewardToken(stRESOLV);
+
+        // Cannot sweep stUSR
+        vm.expectRevert(abi.encodeWithSelector(P2pResolvProxy__CannotSweepProtectedToken.selector, stUSR));
+        P2pResolvProxy(proxyAddress).sweepRewardToken(stUSR);
+
+        vm.stopPrank();
+    }
+
+    function test_sweepRewardToken_zeroBalance_Mainnet_RESOLV() public {
+        deal(RESOLV, clientAddress, 1000e18);
+        _doDeposit();
+
+        address rewardToken = makeAddr("rewardToken");
+
+        // Mock zero balance
+        vm.mockCall(
+            rewardToken,
+            abi.encodeWithSelector(IERC20.balanceOf.selector, proxyAddress),
+            abi.encode(0)
+        );
+
+        // Should not emit event or make transfer call
+        vm.startPrank(clientAddress);
+        P2pResolvProxy(proxyAddress).sweepRewardToken(rewardToken);
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
+    }
+
+    function test_sweepRewardToken_onlyClientOrOperator_Mainnet_RESOLV() public {
+        deal(RESOLV, clientAddress, 1000e18);
+        _doDeposit();
+
+        address rewardToken = makeAddr("rewardToken");
+
+        vm.startPrank(nobody);
+        vm.expectRevert(abi.encodeWithSelector(P2pResolvProxy__CallerNeitherClientNorP2pOperator.selector, nobody));
+        P2pResolvProxy(proxyAddress).sweepRewardToken(rewardToken);
+        vm.stopPrank();
     }
 
     function test_transferP2pSigner_Mainnet_RESOLV() public {

--- a/test/USRIntegration.sol
+++ b/test/USRIntegration.sol
@@ -231,6 +231,16 @@ contract USRIntegration is Test {
         vm.stopPrank();
     }
 
+    function test_withdrawUSR_zeroAmount_reverts() public {
+        deal(USR, clientAddress, DepositAmount);
+        _doDeposit();
+
+        vm.startPrank(clientAddress);
+        vm.expectRevert(P2pYieldProxy__ZeroAssetAmount.selector);
+        P2pResolvProxy(proxyAddress).withdrawUSR(0);
+        vm.stopPrank();
+    }
+
     function test_transferP2pSigner_Mainnet() public {
         vm.startPrank(nobody);
         vm.expectRevert(abi.encodeWithSelector(P2pOperator.P2pOperator__UnauthorizedAccount.selector, nobody));

--- a/test/USRIntegration.sol
+++ b/test/USRIntegration.sol
@@ -68,8 +68,7 @@ contract USRIntegration is Test {
             USR,
             stRESOLV,
             RESOLV,
-            address(tup),
-            StakedTokenDistributor
+            address(tup)
         );
         vm.stopPrank();
 


### PR DESCRIPTION
H1 StakedTokenDistributor Immutability Breaks Claim Functionality
M1 RESOLV Withdrawal Double Fee When claimEnabled is false
M2 Extra Reward Tokens from ResolvStaking Stuck in P2pResolvProxy
M3 Profit Misclassification Due to Stale Rewards Calculation
L1 s_totalWithdrawn Can Exceed s_totalDeposited Due to Unaccounted Airdropped Tokens or Direct Transfers
L2 Code Duplication in claimStakedTokenDistributor() Access Control
L3 Missing Zero-Value Validation in withdrawUSR() Leads to No-Op Withdrawals
